### PR TITLE
Update to singularity 3.4.1

### DIFF
--- a/src/main/python/compilation/compiler.py
+++ b/src/main/python/compilation/compiler.py
@@ -83,7 +83,6 @@ def compile_singularity_pm(executable, app_folder):
 	output_template = create_singularity_template(configuration, executable, connection_url, compilation_folder)
 
 	# We create the image and we build the container
-	create_singularity_image(configuration, connection_url, _singularity_pm_image_)
 	image_file = build_singularity_container(connection_url, output_template, _singularity_pm_image_, app_folder, become=become)
 
 	executable.singularity_image_file = image_file
@@ -105,11 +104,11 @@ def build_singularity_container(connection_url, template, image_file, upload_fol
 		template = os.path.basename(template)
 
 	if become:
-		logging.info("Executing [%s], 'sudo singulary bootstrap %s %s'", connection_url, image_file, template)
-		shell.execute_command('sudo', connection_url, ['singularity', 'bootstrap', image_file, template ])
+		logging.info("Executing [%s], 'sudo singulary build -F %s %s'", connection_url, image_file, template)
+		shell.execute_command('sudo', connection_url, ['singularity', 'build', '-F', image_file, template ])
 	else:
-		logging.info("Executing [%s], 'singulary bootstrap %s %s'", connection_url, image_file, template)
-		shell.execute_command('singularity', connection_url, ['bootstrap', image_file, template ])
+		logging.info("Executing [%s], 'singulary build -F %s %s'", connection_url, image_file, template)
+		shell.execute_command('singularity', connection_url, ['build', '-F', image_file, template ])
 
 	if connection_url != '':
 		logging.info("Downloading image from %s", connection_url)

--- a/src/main/python/shell.py
+++ b/src/main/python/shell.py
@@ -58,7 +58,7 @@ def execute_command(command, server='', params=[]):
         if server != '':
             command = ""
             for param in params:
-                command = command + " " + param
+                command = command + " " + str(param)
 
             params = []
             params.append('ssh')

--- a/src/main/python/slurm.py
+++ b/src/main/python/slurm.py
@@ -366,7 +366,7 @@ def execute_srun(testbed, execution_configuration, executable, deployment, singu
     """
 
 	# Preparing the command to be executed
-    command = "("
+    command = "' ("
     endpoint = testbed.endpoint
     params = []
     params.append("srun")
@@ -395,6 +395,7 @@ def execute_srun(testbed, execution_configuration, executable, deployment, singu
     params.append("sleep")
     params.append("1;")
     params.append("squeue")
+    params.append("'")
     
     logging.info("Launching execution of application: command: " + command + " | endpoint: " + endpoint + " | params: " + str(params))
     

--- a/src/unittest/python/compilation_tests/compiler_tests.py
+++ b/src/unittest/python/compilation_tests/compiler_tests.py
@@ -126,7 +126,7 @@ class CompilerTests(MappingTest):
 		# We verify that the creation of the template is done
 		mock_create_sing_template.assert_called_with(configuration, executable, 'ubuntu@localhost:2222', 'dest_folder')
 		# We verify that the image was created
-		mock_image.assert_called_with(configuration, 'ubuntu@localhost:2222', 'singularity_pm.img')
+		#mock_image.assert_called_with(configuration, 'ubuntu@localhost:2222', 'singularity_pm.img')
 		# We verify that the container was build
 		mock_build.assert_called_with('ubuntu@localhost:2222', 'template.def', 'singularity_pm.img', 'asdf', become=True)
 
@@ -183,20 +183,20 @@ class CompilerTests(MappingTest):
 
 		## WE VERIFY ALL THE CALLS:
 
-		call_1 = call('sudo', 'asdf@asdf.com', ['singularity', 'bootstrap', 'image.img', 'test.def'])
-		call_2 = call('singularity', 'asdf@asdf.com', ['bootstrap', 'image.img', 'test.def'])
-		call_3 = call('singularity', '', ['bootstrap', 'image.img', '/test/test.def'])
+		call_1 = call('sudo', 'asdf@asdf.com', ['singularity', 'build', '-F', 'image.img', 'test.def'])
+		call_2 = call('singularity', 'asdf@asdf.com', ['build', '-F', 'image.img', 'test.def'])
+		call_3 = call('singularity', '', ['build', '-F', 'image.img', '/test/test.def'])
 		call_4 = call('mv', '', [ANY, ANY])
 		calls = [ call_1, call_2, call_3, call_4]
 		mock_shell.assert_has_calls(calls)
 
 		# Checking that we are logging the correct messages
 		l.check(
-			('root', 'INFO', "Executing [asdf@asdf.com], 'sudo singulary bootstrap image.img test.def'"),
+			('root', 'INFO', "Executing [asdf@asdf.com], 'sudo singulary build -F image.img test.def'"),
 			('root', 'INFO', 'Downloading image from asdf@asdf.com'),
-			('root', 'INFO', "Executing [asdf@asdf.com], 'singulary bootstrap image.img test.def'"),
+			('root', 'INFO', "Executing [asdf@asdf.com], 'singulary build -F image.img test.def'"),
 			('root', 'INFO', 'Downloading image from asdf@asdf.com'),
-			('root', 'INFO', "Executing [], 'singulary bootstrap image.img /test/test.def'"),
+			('root', 'INFO', "Executing [], 'singulary build -F image.img /test/test.def'"),
 			('root', 'INFO', 'Moving image to final destination')
 			)
 		l.uninstall()


### PR DESCRIPTION
Commands to create an image have slightly changed from version 2 to 3. 

In version 2, it required two steps:

1. singularity create -F ...
2. singularity bootstrap ...

In version 3, just one step was needed:

1. singularity build -F ...
